### PR TITLE
:twisted_rightwards_arrows: Fix a null reference for bird pentads

### DIFF
--- a/dotnet/BeakPeekApi/Controllers/BirdController.cs
+++ b/dotnet/BeakPeekApi/Controllers/BirdController.cs
@@ -294,7 +294,7 @@ namespace BeakPeekApi.Controllers
             var birds = await _context.Provinces
                 .Include(p => p.Bird)
                 .Include(p => p.Pentad)
-                .Where(p => p.Bird.Ref == id)
+                .Where(p => p.Bird!.Ref == id)
                 .ToListAsync();
 
             if (birds == null || birds.Count == 0)


### PR DESCRIPTION
# :wrench: Fix

- Fixed a problem in BirdController.cs in the `GetBirdsByRef(int id)` method that doesn't account for a bird being null