### PR TITLE
👷 The aab is now only uploaded if the version name isn't already on google play

### DIFF
--- a/.github/workflows/deploy_flutter.yml
+++ b/.github/workflows/deploy_flutter.yml
@@ -3,9 +3,6 @@ name: 📢 Publish Android release
 on:
   release:
     types: [published]
-  # push:
-  #   branches:
-  #     - 'dev/feat/devops'
   workflow_dispatch:
   workflow_call:
 
@@ -86,21 +83,10 @@ jobs:
         env:
           ANDROID_KEY_STORE_PASSWORD: ${{ secrets.ANDROID_KEY_STORE_PASSWORD }}
 
-      # - name: Cache Flutter dependancies
-      #   uses: actions/cache@v3
-      #   with:
-      #     path: |
-      #       ~/.pub-cache
-      #       ~/.flutter
-      #     key: ${{ runner.os }}-pub-${{ hashFiles('**/pubspec.yaml') }}
-      #     restore-keys: |
-      #       ${{ runner.os }}-pub-${{ hashFiles('**/pubspec.yaml') }}
-
       - name: Build and Release to Google Play
         uses: maierj/fastlane-action@v3.1.0
         with:
-          # lane: 'release_play_store'
-          lane: 'build'
+          lane: 'release_play_store'
           subdirectory: ./beakpeek/android
           options: '{ "version_number": "${{ github.ref_name }}" }'
         env:

--- a/beakpeek/Fastfile
+++ b/beakpeek/Fastfile
@@ -31,7 +31,7 @@ lane :build_flutter_app do |options|
 
   type = options[:type]
   build_number = options[:build_number] || get_build_number(options[:store])
-  version_number = options[:version_number] || pubspec_version_number
+  version_number = pubspec_version_number  || options[:version_number]
   no_codesign = options[:no_codesign] || false
   config_only = options[:config_only] || false
   commit = last_git_commit
@@ -90,6 +90,13 @@ def get_build_number(store)
     package_name: store == "playstore" ? ENV["APP_PACKAGE_NAME"] : nil,
     google_play_json_key_path: google_service_account_json_path
   ).to_s
+end
+
+def get_release_name()
+  return google_play_track_release_names(
+    track: "internal",
+    json_key: google_service_account_json_path
+  )
 end
 
 

--- a/beakpeek/android/fastlane/Fastfile
+++ b/beakpeek/android/fastlane/Fastfile
@@ -1,56 +1,59 @@
-import "../../Fastfile"
+import '../../Fastfile'
 
 default_platform(:android)
 
 platform :android do
-
+  lane :get_release_names do |_options|
+    get_release_name
+  end
   # Build flutter Android app
   lane :build do |options|
     verify_env(envs: [
-      "APP_PACKAGE_NAME"
-    ])
+                 'APP_PACKAGE_NAME'
+               ])
 
     # Verify 'firebase_app_distribution_service_account.json' file exists
     unless File.exist?(google_service_account_json_path)
-      UI.user_error!("google_service_account.json file not found. Please add it to the root of the flutter project. See https://docs.fastlane.tools/actions/supply/")
+      UI.user_error!('google_service_account.json file not found. Please add it to the root of the flutter project. See https://docs.fastlane.tools/actions/supply/')
     end
 
     # Verify version number is correct
     if !is_ci && (!options[:version_number])
-      version_number = get_version_from_pubspec()
+      version_number = get_version_from_pubspec
       continue = UI.confirm("Deploying version #{version_number} (from pubspec.yaml) to Play Store. Continue?")
 
-      unless continue
-        UI.user_error!("Aborted")
-      end
+      UI.user_error!('Aborted') unless continue
     end
 
     build_flutter_app(
-      type: options[:type] || "appbundle",
+      type: options[:type] || 'appbundle',
       no_codesign: options[:no_codesign],
       config_only: options[:config_only],
       build_number: options[:build_number],
       version_number: options[:version_number],
-      store: "playstore"
+      store: 'playstore'
     )
   end
 
   # Release to Play Store using Fastlane Supply (https://docs.fastlane.tools/actions/supply/)
-  desc "Release to Play Store"
+  desc 'Release to Play Store'
   lane :release_play_store do |options|
-    begin
-      build(
-        no_codesign: options[:no_codesign],
-        config_only: options[:config_only],
-        build_number: options[:build_number],
-        version_number: options[:version_number]
-      )
+    build(
+      no_codesign: options[:no_codesign],
+      config_only: options[:config_only],
+      build_number: options[:build_number],
+      version_number: options[:version_number]
+    )
 
+    if get_release_name.include? get_version_from_pubspec
+      puts 'Release name is the same as the one on google play'
+      puts 'Upload will not continue but build will still happen'
+    else
       supply(
         track: 'internal',
         # Uncomment this if getting error "Only releases with status draft may be created on draft app."
         # release_status: 'draft',
-        aab: "../build/app/outputs/bundle/release/app-release.aab",
+        aab: '../build/app/outputs/bundle/release/app-release.aab',
         json_key: google_service_account_json_path,
         skip_upload_apk: true, # Upload the aab instead of apk
         skip_upload_metadata: true,
@@ -62,24 +65,22 @@ platform :android do
   end
 
   # Release to Play Store using Firebase App Distribution (https://docs.fastlane.tools/actions/firebase_app_distribution/)
-  desc "Release to Play Store using Firebase App Distribution"
+  desc 'Release to Play Store using Firebase App Distribution'
   lane :release_play_store_using_firebase do |options|
-    begin
-      build(
-        type: 'apk',
-        no_codesign: options[:no_codesign],
-        config_only: options[:config_only],
-        build_number: options[:build_number],
-        version_number: options[:version_number]
-      )
+    build(
+      type: 'apk',
+      no_codesign: options[:no_codesign],
+      config_only: options[:config_only],
+      build_number: options[:build_number],
+      version_number: options[:version_number]
+    )
 
-      firebase_app_distribution(
-        app: ENV["FIREBASE_APP_ID"],
-        android_artifact_path: "#{root_path}/build/app/outputs/flutter-apk/app-release.apk",
-        service_credentials_file: google_service_account_json_path,
-        # Use the following to enable debug mode
-        debug: true
-      )
-    end
+    firebase_app_distribution(
+      app: ENV['FIREBASE_APP_ID'],
+      android_artifact_path: "#{root_path}/build/app/outputs/flutter-apk/app-release.apk",
+      service_credentials_file: google_service_account_json_path,
+      # Use the following to enable debug mode
+      debug: true
+    )
   end
 end

--- a/beakpeek/android/fastlane/README.md
+++ b/beakpeek/android/fastlane/README.md
@@ -66,6 +66,14 @@ For _fastlane_ installation instructions, see [Installing _fastlane_](https://do
 
 ## Android
 
+### android get_release_names
+
+```sh
+[bundle exec] fastlane android get_release_names
+```
+
+
+
 ### android build
 
 ```sh


### PR DESCRIPTION
# ✨ Changes

- 👷 The app version name (from the `pubspec.yaml`) is now checked against the the release name on the google play store
- 👷 If the version from the pubspec is already on google play nothing will be uploaded but the aab will still be built